### PR TITLE
ops/qg-xx: В скрипт обновления сертификата добавлен перезапуск nginx-а

### DIFF
--- a/deploy/host/update-cert.sh
+++ b/deploy/host/update-cert.sh
@@ -1,1 +1,3 @@
+cd ../server || exit
 ansible-playbook -v -i ./hosts -u root ./qyoga-server.yaml --tags "cert"
+ssh root@trainer-advisor.pro "sudo systemctl restart nginx.service"

--- a/deploy/host/update-nginx-conf.sh
+++ b/deploy/host/update-nginx-conf.sh
@@ -1,2 +1,2 @@
-cd ../server
+cd ../server || exit
 ansible-playbook -v -i ./hosts -u root ./qyoga-server.yaml --tags "configure-nginx"

--- a/deploy/server/hosts
+++ b/deploy/server/hosts
@@ -1,1 +1,1 @@
-80.249.145.23
+trainer-advisor.pro


### PR DESCRIPTION
Потому что в прошлый раз скрипт вроде бы отрабатывал без проблем, но сертификат не обновился. Пока обновлял вроде ничего особого не сделал, кроме как рестартанул nginx